### PR TITLE
Implement verification id.

### DIFF
--- a/README-DE.md
+++ b/README-DE.md
@@ -165,6 +165,11 @@ Der Aufruf erzeugt eine Datei[^1], die folgendes Format hat:
 Es handelt sich um eine `json`-Datei, deren Aufbau und die Bedeutung der Felder in [Dateiformat.md](doc/de/Dateiformat.md) beschrieben ist.
 Eine ausführliche Beschreibung der verschiedenen Berechnungen und Datenformate ist in [Technische_Spezifikation.md](doc/de/Technische_Spezifikation.md) zu finden.
 
+Wenn das Programm läuft, gibt es eine ausführliche Beschreibung seiner Arbeit aus.
+Die Ausgabe enthält eine sogenannte "verification id".
+Diese Verification-Id wird für die Überprüfung der Signaturen benötigt.
+Sie ist die Information, die an einem sicheren Ort veröffentlicht werden sollte.
+
 Die Rückgabe-Codes können sein:
 
 | Code | Bedeutung                    |
@@ -179,14 +184,15 @@ Die Rückgabe-Codes können sein:
 Der Aufruf zur Verifizierung sieht folgendermaßen aus:
 
 ```
-filesigner verify [-m|--name {name}]
+filesigner verify [-m|--name {name}] {verificationId}
 ```
 
 Die einzelnen Teile haben die folgenden Bedeutungen:
 
-| Teil           | Bedeutung                                                                                                                                                                  |
-|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `name`         | Die Signaturendatei hat den Namen `{name}-signatures.json`. Die Voreinstellung für den Namen ist `filesigner`.                                                             |
+| Teil             | Bedeutung                                                                                                      |
+|------------------|----------------------------------------------------------------------------------------------------------------|
+| `name`           | Die Signaturendatei hat den Namen `{name}-signatures.json`. Die Voreinstellung für den Namen ist `filesigner`. |
+| `verificationId` | Die veröffentlichte Verification-Id aus dem Signiervorgang.                                                    |
 
 > [!IMPORTANT]
 > Weitere Parameter sind nicht erlaubt und führen zu einer Fehlermeldung.
@@ -219,11 +225,12 @@ filesigner sign project1711 -if *.go -if filesign*
 Das Programm erzeugt dann die folgende Ausgabe auf der Konsole:
 
 ```
-2024-03-05 15:48:51 +01:00  15  I  filesigner V0.83.1 (go1.24.3, 8 cpus)
+2024-03-05 15:48:51 +01:00  15  I  filesigner V0.90.0 (go1.24.3, 8 cpus)
 2024-03-05 15:48:51 +01:00  24  I  Context id         : project1711
 2024-03-05 15:48:51 +01:00  25  I  Public key id      : DLQB-J6MT-YMF1-PPRF-KQ6P-V9LG-QR
 2024-03-05 15:48:51 +01:00  26  I  Signature timestamp: 2024-03-05 15:48:51 +01:00
 2024-03-05 15:48:51 +01:00  27  I  Signature host name: Jetzt
+2024-03-05 15:48:51 +01:00  37  I  Verification id    : P801-RPM6-C5SQ-0X9D-BVEZ-EK9M-MR
 2024-03-05 15:48:51 +01:00  21  I  Signing succeeded for file 'common.go'
 2024-03-05 15:48:51 +01:00  21  I  Signing succeeded for file 'filesigner'
 2024-03-05 15:48:51 +01:00  21  I  Signing succeeded for file 'filesigner.exe'
@@ -244,13 +251,13 @@ Dabei kann es sich um eine signierte E-Mail, eine Website, eine Datenbank oder e
 Zur Verifizierung ruft man das Programm folgendermaßen auf:
 
 ```
-filesigner verify project1711
+filesigner verify P801-RPM6-C5SQ-0X9D-BVEZ-EK9M-MR
 ```
 
 Das Programm erzeugt dann die folgende Ausgabe auf der Konsole:
 
 ```
-2024-03-05 15:49:13 +01:00  15  I  filesigner V0.83.1 (go1.24.3, 8 cpus)
+2024-03-05 15:49:13 +01:00  15  I  filesigner V0.90.0 (go1.24.3, 8 cpus)
 2024-03-05 15:49:13 +01:00  51  I  Reading signatures file 'filesigner-signatures.json'
 2024-03-05 15:49:13 +01:00  24  I  Context id         : project1711
 2024-03-05 15:49:13 +01:00  25  I  Public key id      : DLQB-J6MT-YMF1-PPRF-KQ6P-V9LG-QR
@@ -274,7 +281,7 @@ Ist dies nicht der Fall, wird die Signatur als ungültig angesehen und die Datei
 Sollte, als weiteres Beispiel, die Datei `filesigner` manipuliert worden sein, würde folgende Ausgabe erscheinen:
 
 ```
-2024-03-05 15:49:38 +01:00  15  I  filesigner V0.83.1 (go1.24.3, 8 cpus)
+2024-03-05 15:49:38 +01:00  15  I  filesigner V0.90.0 (go1.24.3, 8 cpus)
 2024-03-05 15:49:38 +01:00  51  I  Reading signatures file 'filesigner-signatures.json'
 2024-03-05 15:49:38 +01:00  24  I  Context id         : project1711
 2024-03-05 15:49:38 +01:00  25  I  Public key id      : DLQB-J6MT-YMF1-PPRF-KQ6P-V9LG-QR
@@ -295,7 +302,7 @@ Der Rückgabe-Code ist 3.
 Sollte z.B. die Signaturdatei manipuliert worden sein, würde folgende Ausgabe erscheinen:
 
 ```
-2024-03-05 15:50:04 +01:00  15  I  filesigner V0.83.1 (go1.24.3, 8 cpus)
+2024-03-05 15:50:04 +01:00  15  I  filesigner V0.90.0 (go1.24.3, 8 cpus)
 2024-03-05 15:50:04 +01:00  51  I  Reading signatures file 'filesigner-signatures.json'
 2024-03-05 15:50:04 +01:00  54  E  Signatures file has been modified
 ```

--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ The call creates a signatures file[^1] which has the following format:
 This is a `json` file whose structure and the meaning of the fields are described in [file_format.md](doc/en/file_format.md).
 A detailed description of the various calculations and data formats can be found in [technical_specification.md](doc/en/technical_specification.md).
 
+When the program runs, it prints a detailed description of its operations.
+The output contains a so-called "verification id".
+This verification id is needed for the verification of the signatures.
+It is the information that should be published in a safe place.
+
 The possible return codes are the following:
 
 | Code | Meaning                   |
@@ -141,14 +146,15 @@ The possible return codes are the following:
 The verification call looks like this:
 
 ```
-filesigner verify [-m|--name {name}]
+filesigner verify [-m|--name {name}] {verificationId}
 ```
 
 The parts have the following meaning:
 
-| Part           | Meaning                                                                                                                                                         |
-|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `name`         | The signatures file name is `{name}-signatures.json`. Default for the name is `filesigner`.                                                                     |
+| Part             | Meaning                                                                                     |
+|------------------|---------------------------------------------------------------------------------------------|
+| `name`           | The signatures file name is `{name}-signatures.json`. Default for the name is `filesigner`. |
+| `verificationId` | The verification id of the signature process that has been published.                       |
 
 > [!IMPORTANT]
 > More parameters are not permitted and will result in an error message.
@@ -187,11 +193,12 @@ filesigner sign project1711 -if *.go -if filesign*
 The program then generates the following output on the console:
 
 ```
-2024-03-05 15:48:51 +01:00  15  I  filesigner V0.83.1 (go1.24.3, 8 cpus)
+2024-03-05 15:48:51 +01:00  15  I  filesigner V0.90.0 (go1.24.3, 8 cpus)
 2024-03-05 15:48:51 +01:00  24  I  Context id         : project1711
 2024-03-05 15:48:51 +01:00  25  I  Public key id      : DLQB-J6MT-YMF1-PPRF-KQ6P-V9LG-QR
 2024-03-05 15:48:51 +01:00  26  I  Signature timestamp: 2024-03-05 15:48:51 +01:00
 2024-03-05 15:48:51 +01:00  27  I  Signature host name: Jetzt
+2024-03-05 15:48:51 +01:00  37  I  Verification id    : P801-RPM6-C5SQ-0X9D-BVEZ-EK9M-MR
 2024-03-05 15:48:51 +01:00  21  I  Signing succeeded for file 'common.go'
 2024-03-05 15:48:51 +01:00  21  I  Signing succeeded for file 'filesigner'
 2024-03-05 15:48:51 +01:00  21  I  Signing succeeded for file 'filesigner.exe'
@@ -199,26 +206,26 @@ The program then generates the following output on the console:
 2024-03-05 15:48:51 +01:00  21  I  Signing succeeded for file 'main.go'
 2024-03-05 15:48:51 +01:00  21  I  Signing succeeded for file 'sign_command.go'
 2024-03-05 15:48:51 +01:00  21  I  Signing succeeded for file 'verify_command.go'
-2024-03-05 15:48:51 +01:00  37  I  Signatures for 7 files successfully created and written to 'filesigner-signatures.json'
+2024-03-05 15:48:51 +01:00  38  I  Signatures for 7 files successfully created and written to 'filesigner-signatures.json'
 ```
 
 The return code is 0.
 
 ### Verifying
 
-To verify the signatures one needs a trusted place where the public key id, the signature timestamp and the signature host name are published.
+To verify the signatures one needs a trusted place where the verification id is published.
 This may be a signed email, a website, a database, or whatever is deemed to be a secure trusted place.
 
 Then the verifier runs the filesigner program with the following parameters:
 
 ```
-filesigner verify
+filesigner verify P801-RPM6-C5SQ-0X9D-BVEZ-EK9M-MR
 ```
 
 The program then generates the following output on the console:
 
 ```
-2024-03-05 15:49:13 +01:00  15  I  filesigner V0.83.1 (go1.24.3, 8 cpus)
+2024-03-05 15:49:13 +01:00  15  I  filesigner V0.90.0 (go1.24.3, 8 cpus)
 2024-03-05 15:49:13 +01:00  51  I  Reading signatures file 'filesigner-signatures.json'
 2024-03-05 15:49:13 +01:00  24  I  Context id         : project1711
 2024-03-05 15:49:13 +01:00  25  I  Public key id      : DLQB-J6MT-YMF1-PPRF-KQ6P-V9LG-QR
@@ -242,7 +249,7 @@ If this is not the case, the signature is deemed to be invalid and the files mus
 As another example, if the file `filesigner` has been manipulated, the following output would appear:
 
 ```
-2024-03-05 15:49:38 +01:00  15  I  filesigner V0.83.1 (go1.24.3, 8 cpus)
+2024-03-05 15:49:38 +01:00  15  I  filesigner V0.90.0 (go1.24.3, 8 cpus)
 2024-03-05 15:49:38 +01:00  51  I  Reading signatures file 'filesigner-signatures.json'
 2024-03-05 15:49:38 +01:00  24  I  Context id         : project1711
 2024-03-05 15:49:38 +01:00  25  I  Public key id      : DLQB-J6MT-YMF1-PPRF-KQ6P-V9LG-QR
@@ -260,10 +267,10 @@ As another example, if the file `filesigner` has been manipulated, the following
 
 The return code is 3.
 
-If, for example, the signatures file has been manipulated the following output would appear:
+If, for example, the signatures file has been manipulated, the following output would appear:
 
 ```
-2024-03-05 15:50:04 +01:00  15  I  filesigner V0.83.1 (go1.24.3, 8 cpus)
+2024-03-05 15:50:04 +01:00  15  I  filesigner V0.90.0 (go1.24.3, 8 cpus)
 2024-03-05 15:50:04 +01:00  51  I  Reading signatures file 'filesigner-signatures.json'
 2024-03-05 15:50:04 +01:00  54  E  Signatures file has been modified
 ```

--- a/cmdline/command_line_verify.go
+++ b/cmdline/command_line_verify.go
@@ -20,11 +20,12 @@
 //
 // Author: Frank Schwab
 //
-// Version: 1.0.1
+// Version: 2.0.0
 //
 // Change history:
 //    2024-02-08: V1.0.0: Created.
 //    2024-04-05: V1.0.1: Make Stdout the output destination for usage messages.
+//    2025-05-23: V2.0.0: Add verification id.
 //
 
 package cmdline
@@ -33,6 +34,7 @@ import (
 	"errors"
 	"github.com/spf13/pflag"
 	"os"
+	"strings"
 )
 
 // ******** Public types ********
@@ -42,6 +44,7 @@ import (
 type VerifyCommandLine struct {
 	// Public elements
 	SignaturesFileName string
+	VerificationId     string
 
 	// Private elements
 	fs     *pflag.FlagSet
@@ -59,6 +62,7 @@ func NewVerifyCommandLine() *VerifyCommandLine {
 	result := &VerifyCommandLine{fs: verifyCmd}
 
 	verifyCmd.StringVarP(&result.prefix, `name`, `m`, defaultSignaturesFileNamePrefix, `Prefix of the signatures file name`)
+	verifyCmd.StringVarP(&result.VerificationId, `verificationid`, `v`, ``, `Verification id`)
 
 	verifyCmd.SortFlags = true
 
@@ -93,6 +97,11 @@ func (cl *VerifyCommandLine) ExtractCommandData() error {
 	err := checkSignaturesFileName(cl.SignaturesFileName)
 	if err != nil {
 		return err
+	}
+
+	cl.VerificationId = strings.TrimSpace(cl.VerificationId)
+	if len(cl.VerificationId) == 0 {
+		return errors.New(`Verification id must not be empty`)
 	}
 
 	return nil

--- a/cmdline/command_line_verify.go
+++ b/cmdline/command_line_verify.go
@@ -62,7 +62,6 @@ func NewVerifyCommandLine() *VerifyCommandLine {
 	result := &VerifyCommandLine{fs: verifyCmd}
 
 	verifyCmd.StringVarP(&result.prefix, `name`, `m`, defaultSignaturesFileNamePrefix, `Prefix of the signatures file name`)
-	verifyCmd.StringVarP(&result.VerificationId, `verificationid`, `v`, ``, `Verification id`)
 
 	verifyCmd.SortFlags = true
 
@@ -76,9 +75,14 @@ func (cl *VerifyCommandLine) Parse(args []string) (error, bool) {
 		return nil, true
 	}
 
-	if cl.fs.NArg() != 0 {
-		return errors.New(`There must be no arguments present without options`), false
+	if cl.fs.NArg() == 0 {
+		return errors.New(`Verification id is missing`), false
 	}
+	if cl.fs.NArg() > 1 {
+		return errors.New(`Too many arguments present without options`), false
+	}
+
+	cl.VerificationId = strings.TrimSpace(cl.fs.Arg(0))
 
 	return err, false
 }
@@ -99,7 +103,6 @@ func (cl *VerifyCommandLine) ExtractCommandData() error {
 		return err
 	}
 
-	cl.VerificationId = strings.TrimSpace(cl.VerificationId)
 	if len(cl.VerificationId) == 0 {
 		return errors.New(`Verification id must not be empty`)
 	}

--- a/common.go
+++ b/common.go
@@ -89,11 +89,10 @@ func printMetaData(
 	logger.PrintInfof(commonMsgBase+5, `Public key id      : %s`, keyid.KeyId(publicKeyBytes))
 	logger.PrintInfof(commonMsgBase+6, `Signature timestamp: %s`, signatureData.Timestamp)
 	logger.PrintInfof(commonMsgBase+7, `Signature host name: %s`, signatureData.Hostname)
-	logger.PrintInfof(commonMsgBase+8, `Verifier           : %s`, verifyString(signatureData, publicKeyBytes))
 }
 
-// verifyString returns the verify string for the given data.
-func verifyString(
+// makeVerificationId returns the verification id for the given data.
+func makeVerificationId(
 	signatureData *signaturehandler.SignatureData,
 	publicKeyBytes []byte) string {
 	return keyid.KeyId(

--- a/common.go
+++ b/common.go
@@ -35,6 +35,7 @@ import (
 	"filesigner/logger"
 	"filesigner/maphelper"
 	"filesigner/signaturehandler"
+	"filesigner/stringhelper"
 	"sort"
 )
 
@@ -88,4 +89,17 @@ func printMetaData(
 	logger.PrintInfof(commonMsgBase+5, `Public key id      : %s`, keyid.KeyId(publicKeyBytes))
 	logger.PrintInfof(commonMsgBase+6, `Signature timestamp: %s`, signatureData.Timestamp)
 	logger.PrintInfof(commonMsgBase+7, `Signature host name: %s`, signatureData.Hostname)
+	logger.PrintInfof(commonMsgBase+8, `Verifier           : %s`, verifyString(signatureData, publicKeyBytes))
+}
+
+// verifyString returns the verify string for the given data.
+func verifyString(
+	signatureData *signaturehandler.SignatureData,
+	publicKeyBytes []byte) string {
+	return keyid.KeyId(
+		stringhelper.UnsafeStringBytes(signatureData.ContextId),
+		publicKeyBytes,
+		stringhelper.UnsafeStringBytes(signatureData.Timestamp),
+		stringhelper.UnsafeStringBytes(signatureData.Hostname),
+	)
 }

--- a/main.go
+++ b/main.go
@@ -227,7 +227,7 @@ Sign files:
 
 Verify files:
 `)
-	_, _ = fmt.Printf(`  %s verify [flag]`, myName)
+	_, _ = fmt.Printf(`  %s verify [flag] {verificationId}`, myName)
 	_, _ = fmt.Print(`
 
   with 'flag' being the following:
@@ -235,6 +235,7 @@ Verify files:
 `)
 	vcl.PrintUsage()
 	_, _ = fmt.Print(`
+  The 'verificationId' is the verification id printed when the signatures were created.
   All the files in the signatures file will be verified.
 
 

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@
 //
 // Author: Frank Schwab
 //
-// Version: 0.83.1
+// Version: 0.90.0
 //
 
 package main
@@ -41,7 +41,7 @@ import (
 var myName string
 
 // myVersion contains the program version.
-const myVersion = `0.83.1`
+const myVersion = `0.90.0`
 
 // mainMsgBase is the base number for all messages in main.
 // This file reserves numbers 10-19.

--- a/main.go
+++ b/main.go
@@ -133,7 +133,7 @@ func mainWithReturnCode(args []string) int {
 			return rc
 		}
 
-		return doVerification(vcl.SignaturesFileName)
+		return doVerification(vcl.SignaturesFileName, vcl.VerificationId)
 
 	default:
 		return printUsageErrorf(mainMsgBase+3, `Unknown command: '%s'`, command)

--- a/sign_command.go
+++ b/sign_command.go
@@ -127,6 +127,8 @@ func doSigning(
 
 	printMetaData(signatureData, publicKeyBytes)
 
+	logger.PrintInfof(signCmdMsgBase+7, `Verification id    : %s`, makeVerificationId(signatureData, publicKeyBytes))
+
 	successCount := len(successList)
 	if successCount > 0 {
 		printSuccessList(`Signing`, successList)
@@ -134,14 +136,12 @@ func doSigning(
 
 	successEnding := texthelper.GetCountEnding(successCount)
 
-	logger.PrintInfof(signCmdMsgBase+7,
+	logger.PrintInfof(signCmdMsgBase+8,
 		`Signature%s for %d file%s successfully created and written to '%s'`,
 		successEnding,
 		len(successList),
 		successEnding,
 		signaturesFileName)
-
-	logger.PrintInfof(signCmdMsgBase+8, `Verification id    : %s`, makeVerificationId(signatureData, publicKeyBytes))
 
 	return rcOK
 }

--- a/sign_command.go
+++ b/sign_command.go
@@ -140,5 +140,8 @@ func doSigning(
 		len(successList),
 		successEnding,
 		signaturesFileName)
+
+	logger.PrintInfof(signCmdMsgBase+8, `Verification id    : %s`, makeVerificationId(signatureData, publicKeyBytes))
+
 	return rcOK
 }

--- a/verify_command.go
+++ b/verify_command.go
@@ -57,12 +57,13 @@ import (
 // This file reserves numbers 50-69.
 const verifyCmdMsgBase = 50
 
+// errMsgCouldNotConvert is the error message for a base32 conversion error.
 const errMsgCouldNotConvert = `Could not convert %s to bytes: %v`
 
 // ******** Private functions ********
 
 // doVerification verifies a signatures file.
-func doVerification(signaturesFileName string) int {
+func doVerification(signaturesFileName string, parameterVerificationId string) int {
 	logger.PrintInfof(verifyCmdMsgBase+1, `Reading signatures file '%s'`, signaturesFileName)
 
 	signatureData, err := signaturefile.ReadJson(signaturesFileName)
@@ -105,6 +106,11 @@ func doVerification(signaturesFileName string) int {
 		return rcProcessError
 	}
 
+	if makeVerificationId(signatureData, publicKeyBytes) != parameterVerificationId {
+		logger.PrintError(verifyCmdMsgBase+6, `Invalid verification id`)
+		return rcProcessError
+	}
+
 	printMetaData(signatureData, publicKeyBytes)
 
 	successCount, errorCount, rc := verifyFiles(contextKey, signatureData, hashVerifier)
@@ -114,13 +120,13 @@ func doVerification(signaturesFileName string) int {
 
 	switch rc {
 	case rcOK:
-		logger.PrintInfof(verifyCmdMsgBase+6, `Verification of %d file%s successful`, successCount, successEnding)
+		logger.PrintInfof(verifyCmdMsgBase+7, `Verification of %d file%s successful`, successCount, successEnding)
 
 	case rcProcessWarning:
-		logger.PrintInfof(verifyCmdMsgBase+7, `Verification of %d file%s successful and warnings present`, successCount, successEnding)
+		logger.PrintInfof(verifyCmdMsgBase+8, `Verification of %d file%s successful and warnings present`, successCount, successEnding)
 
 	case rcProcessError:
-		logger.PrintInfof(verifyCmdMsgBase+8, `Verification of %d file%s successful and %d file%s unsuccessful`, successCount, successEnding, errorCount, errorEnding)
+		logger.PrintInfof(verifyCmdMsgBase+9, `Verification of %d file%s successful and %d file%s unsuccessful`, successCount, successEnding, errorCount, errorEnding)
 	}
 
 	return rc
@@ -133,7 +139,7 @@ func verifyFiles(contextBytes []byte,
 	filePaths, rc := getExistingFiles(maphelper.Keys(signatureData.FileSignatures))
 
 	if len(filePaths) == 0 {
-		logger.PrintWarning(verifyCmdMsgBase+9, `No files from signatures file present`)
+		logger.PrintWarning(verifyCmdMsgBase+10, `No files from signatures file present`)
 		return 0, 0, rcProcessWarning
 	}
 
@@ -184,15 +190,15 @@ func getExistingFiles(filePaths []string) ([]string, int) {
 		fi, err := os.Stat(nfp)
 		if err != nil {
 			if errors.Is(err, os.ErrNotExist) {
-				logger.PrintWarningf(verifyCmdMsgBase+10, `File '%s' in signatures file does not exist`, nfp)
+				logger.PrintWarningf(verifyCmdMsgBase+11, `File '%s' in signatures file does not exist`, nfp)
 				rc = max(rc, rcProcessWarning)
 			} else {
-				logger.PrintErrorf(verifyCmdMsgBase+11, `Error checking if file '%s' in signatures file exists: %v`, nfp, err)
+				logger.PrintErrorf(verifyCmdMsgBase+12, `Error checking if file '%s' in signatures file exists: %v`, nfp, err)
 				rc = rcProcessError
 			}
 		} else {
 			if fi.IsDir() {
-				logger.PrintWarningf(verifyCmdMsgBase+12, `'%s' in signatures file is a directory`, nfp)
+				logger.PrintWarningf(verifyCmdMsgBase+13, `'%s' in signatures file is a directory`, nfp)
 				rc = max(rc, rcProcessWarning)
 			} else {
 				result = append(result, nfp)


### PR DESCRIPTION
Now the signatures are checked against a verification id. It is no longer necessary to compare the context id, the public key id, the signature timestamp and the signature host. They are all mapped into one datum: The verification id.